### PR TITLE
feat(preprocessing): derive document `head` either from `front` or `b…

### DIFF
--- a/data/staging/AT-OeStA_AdR-MRang-MR-1.-Rep.-KRP-121_RL_DS_IS_AHform.xml
+++ b/data/staging/AT-OeStA_AdR-MRang-MR-1.-Rep.-KRP-121_RL_DS_IS_AHform.xml
@@ -244,8 +244,9 @@
          <div xml:id="doc-krp-0121.xml">
             <head type="dokument">
                <title type="num">121.</title>
-               <title type="desc">|KRP0121_R0001||KRP0121_R0002| [Dienstag] 1919-11-11</title>
+               <title type="desc">[Dienstag] 1919-11-11</title>
             </head>
+            <pb n="2"/>
             <div type="dokumentkopf">
                <div type="vorsitz">
                   <head>Vorsitz:</head>

--- a/data/staging/krp-0169_r.xml
+++ b/data/staging/krp-0169_r.xml
@@ -243,17 +243,13 @@
       <body>
          <div xml:id="doc-krp-0169.xml">
             <head type="dokument">
-               <title type="num"/>
-               <title type="desc"/>
-            </head>
-            <div>
-               <p rend="Title">169.<note place="foot" xml:id="ftn1" n="1">
+               <title type="num">169.<note place="foot" xml:id="ftn1" n="1">
                      <p rend="footnote text"> Das Protokoll trägt den Vermerk Vertraulich!</p>
                   </note>
-               </p>
-               <p rend="Subtitle">
-                  <pb n="3"/>[Freitag] 1920-04-09</p>
-            </div>
+               </title>
+               <title type="desc">[Freitag] 1920-04-09</title>
+            </head>
+            <pb n="3"/>
             <div type="dokumentkopf">
                <div type="vorsitz">
                   <head>Vorsitz:</head>

--- a/preprocessing/xslts/upconvert.xsl
+++ b/preprocessing/xslts/upconvert.xsl
@@ -152,6 +152,9 @@
 
   <!-- suppress front element -->
   <xsl:template match="tei:front"/>
+  
+  <!-- suppress title-and-subtitle div if present -->
+  <xsl:template match="tei:body/tei:div[tei:p[@rend='Title']]"/>
 
   <xsl:template match="tei:body">
     <xsl:copy>
@@ -160,6 +163,12 @@
       <xsl:variable name="body-content" select="node()"/>
       <!-- save front element before xsl:copy changes context -->
       <xsl:variable name="front" select="../tei:front"/>
+      <xsl:variable name="title-container" select="if ($front)
+                then $front//tei:titlePart[@type='Title']
+                else ($body-content/self::tei:div)[1]/tei:p[@rend='Title']"/><!-- allow for both protcol-title containers present in model DOCXs -->
+      <xsl:variable name="subtitle-container" select="if ($front)
+                then $front//tei:titlePart[@type='Subtitle']
+                else ($body-content/self::tei:div)[1]/tei:p[@rend='Subtitle']"/><!-- allow for both protcol-subtitle containers present in model DOCXs -->
       <!-- wrap body content in outermost div from TEI-header document -->
       <xsl:copy select="$header-doc//tei:body/tei:div">
         <xsl:copy-of select="$header-doc//tei:body/tei:div/@*"/>
@@ -168,12 +177,16 @@
         <!-- ================================================================== -->
         <head type="dokument">
           <title type="num">
-            <xsl:value-of select="normalize-space($front//tei:titlePart[@type='Title'])"/>
+            <xsl:value-of select="normalize-space(
+                string-join($title-container//text()[not(ancestor::tei:note)], ''))"/><!-- grab text, but skip footnote -->
+            <xsl:apply-templates select="$title-container//tei:note[@place='foot']"/><!-- pass through footnote -->
           </title>
           <title type="desc"><!-- changed from MRP-style @type='descr' -->
-            <xsl:value-of select="normalize-space($front//tei:titlePart[@type='Subtitle'])"/>
+            <xsl:value-of select="normalize-space(
+                string-join($subtitle-container//text()[not(ancestor::tei:hi[contains(@rend,'background(green)')])], ''))"/><!-- grab text, but skip page markers -->
           </title>
         </head>
+        <xsl:apply-templates select="$subtitle-container//tei:hi[contains(@rend,'background(green)')]"/><!-- pass through page markers from subtitle container -->
         <xsl:apply-templates select="$body-content"/>
       </xsl:copy>
     </xsl:copy>


### PR DESCRIPTION
…ody/div[1]` (#68)