### PR TITLE
feat(preprocessing): drop empty `pb`s, reserve `pb` element for sourc…

### DIFF
--- a/data/staging/krp-0169_r.xml
+++ b/data/staging/krp-0169_r.xml
@@ -438,9 +438,7 @@
                   </head>
                   <p>Nach dem Antrag des StaatssekretärsStöckler beschließt der Kabinettsrat, dass von der Erhebung einer Vorstellung gegen die Gesetzesbeschlüsse des Niederösterreichischen Landtages vom 9. März 1920, betreffend die Regulierung des Moosbaches in den Katastralgemeinden Diesendorf und Asperhofen (Ortsgemeinde Asperhofen) und betreffend die Regulierung des Pielach<pb facs="krp-0169_r-0023"/>flussesin den Katastralgemeinden Loipersdorf und Völlerndorf (Ortsgemeinde Gerersdorf), abgesehen und der sofortigen Kundmachung dieser Gesetzesbeschlüsse unter Gegenzeichnung des Staatssekretärs für Land- und Forstwirtschaft zugestimmt werde.</p>
                   <p>Schluss der Sitzung: 5 Uhr nachmittags.</p>
-                  <p>
-                     <pb/>
-                  </p>
+                  <p/>
                </div>
             </div>
             <div type="stenogramme">
@@ -605,9 +603,7 @@
                   <p n="145">5 Uhr.</p>
                   <p n="146">Nächste Sitzung, Dienstag, ½ 4 Uhr, </p>
                   <p n="147">Parlament.</p>
-                  <p n="148">
-                     <pb/>
-                  </p>
+                  <p n="148"/>
                </div>
             </div>
             <div type="anhänge">

--- a/preprocessing/xslts/upconvert.xsl
+++ b/preprocessing/xslts/upconvert.xsl
@@ -130,6 +130,10 @@
   <!-- Transform page-beginning information -->
   <!-- ================================================================== -->
   
+  <!-- drop empty <pb> elements from transcribers' pagebreaks for visual separation
+       of transcription parts; reserve <pb> for source pagebreaks-->
+  <xsl:template match="tei:pb[not(@*)]"/>
+  
   <!-- note: Saxon indent="yes" inserts whitespace between parent tags and
        adjacent child elements in mixed content (including adding newlines
        before </p> when pb is the last element in the paragraph) - this is


### PR DESCRIPTION
…e pagebreaks (#76)